### PR TITLE
Make sure transmission log instance saved before passing to active job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GIT
 PATH
   remote: .
   specs:
-    renalware-diaverum (0.1.2)
+    renalware-diaverum (0.1.3)
       dotenv-rails
       pg (~> 1.0.0)
       rails (>= 5.1.6)

--- a/app/models/renalware/diaverum/outgoing/pathology_listener.rb
+++ b/app/models/renalware/diaverum/outgoing/pathology_listener.rb
@@ -12,7 +12,6 @@ module Renalware
         # This method intercepts the event raised when an HL7 message has been
         # successfully processed. If the HL7 messages concerns a patient having dialysis at
         # a Diaverum unit, we forward the HL7 message on to Diaverum using a background job
-        # (which lets us queue up jobs if for example the commication mechanism is temporarily down)
         def message_processed(feed_message:, **)
           local_patient_id = feed_message.patient_identifier
           return if local_patient_id.blank?
@@ -31,7 +30,7 @@ module Renalware
         end
 
         def transmission_log_for(patient, feed_message)
-          Renalware::HD::TransmissionLog.new(
+          Renalware::HD::TransmissionLog.create(
             patient: patient,
             payload: feed_message.body,
             format: :hl7,

--- a/lib/renalware/diaverum/version.rb
+++ b/lib/renalware/diaverum/version.rb
@@ -2,6 +2,6 @@
 
 module Renalware
   module Diaverum
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
We were getting the error `Unable to serialize Renalware::HD::TransmissionLog without an id. (Maybe you forgot to call save?)`