### PR TITLE
Remove production constraint

### DIFF
--- a/app/models/renalware/diaverum/incoming/save_session.rb
+++ b/app/models/renalware/diaverum/incoming/save_session.rb
@@ -89,8 +89,7 @@ module Renalware
         end
 
         def save_session(session)
-          # For now skip saving in production
-          if Diaverum.config.diaverum_incoming_skip_session_save || Rails.env.production?
+          if Diaverum.config.diaverum_incoming_skip_session_save
             session.validate!
             log.update!(result: "ok")
           else


### PR DESCRIPTION
Remove production constraint so sessions can now be imported provided
`DIAVERUM_INCOMING_SKIP_SESSION_SAVE=false` in`.env.production`