### PR TITLE
Update renalware-core dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ ruby "~> 2.6.3"
 
 gemspec
 
-gem "devise_security_extension", github: "airslie/devise_security_extension"
-gem "dotenv-rails", "~> 2.5.0"
 gem "nhs_api_client", github: "airslie/nhs_api_client", require: false
 gem "renalware-core", github: "airslie/renalware-core"
 gem "trix", github: "airslie/trix"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,6 @@
 GIT
-  remote: https://github.com/airslie/devise_security_extension.git
-  revision: b2ee978af7d49f0fb0e7271c6ac074dfb4d39353
-  specs:
-    devise_security_extension (0.10.0)
-      devise (>= 3.0.0, < 5.0)
-      railties (>= 3.2.6, < 6.0)
-
-GIT
   remote: https://github.com/airslie/nhs_api_client.git
-  revision: 28a33ff5c4001b626617967171e43a9cec5616a0
+  revision: 5c1732a4540b0fbbeb225129730df3cb469cb95d
   specs:
     nhs_api_client (0.1.0)
       httparty (~> 0.16.4)
@@ -16,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/airslie/renalware-core.git
-  revision: a5e79b6d3cdf34c880b5853cfefbaffbfaa49e1a
+  revision: fd8a6daa1e077c4328337165647de13f2cd0221d
   specs:
-    renalware-core (2.0.79)
+    renalware-core (2.0.88)
       active_type (~> 0.7.1)
       activerecord-import (~> 0.28.0)
       ahoy_matey (~> 2.1)
@@ -33,6 +25,7 @@ GIT
       delayed_job_active_record (~> 4.1.2)
       delayed_job_web (~> 1.4.3)
       devise (~> 4.6.0)
+      devise-security (~> 0.14.3)
       dotenv-rails (~> 2.5)
       dumb_delegator (~> 0.8.0)
       email_validator (~> 1.6.0)
@@ -40,7 +33,7 @@ GIT
       font-awesome-sass (~> 5.6)
       foundation-rails (~> 5.5.3.2)
       friendly_id (~> 5.2.5)
-      hashdiff (~> 0.3.7)
+      hashdiff (~> 0.3.9)
       httparty (~> 0.16)
       i18n (= 1.5.3)
       jbuilder (~> 2.8)
@@ -61,7 +54,7 @@ GIT
       prawn (~> 2.2.2)
       puma (~> 3.12.0)
       pundit (~> 2.0.0)
-      rack-attack (~> 5.4)
+      rack-attack
       rails (~> 5.2)
       rails-assets-foundation-datepicker (= 1.5.0)
       rails-assets-moment (= 2.22.2)
@@ -77,10 +70,10 @@ GIT
       slim-rails (~> 3.2.0)
       uglifier (~> 4.1.17)
       underscore-rails (~> 1.8.3)
-      validates_timeliness (~> 4.0.2)
+      validates_timeliness (~> 4.1.0)
       virtus (~> 1.0.5)
-      whenever (~> 0.10.0)
-      wicked_pdf (~> 1.1.0)
+      whenever
+      wicked_pdf
       wisper (~> 2.0.0)
       wisper-activejob (~> 1.0.0)
       wkhtmltopdf-binary (= 0.12.3.1)
@@ -97,7 +90,7 @@ PATH
   remote: .
   specs:
     renalware-diaverum (1.0.5)
-      dotenv-rails
+      dotenv-rails (~> 2.5)
       pg (~> 1.0)
       rails (>= 5.1)
 
@@ -183,7 +176,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
     byebug (11.0.1)
-    capybara (3.22.0)
+    capybara (3.24.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -191,7 +184,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    capybara-screenshot (1.0.22)
+    capybara-screenshot (1.0.23)
       capybara (>= 1.0, < 4)
       launchy
     character_set (1.4.0)
@@ -205,7 +198,7 @@ GEM
       simple_form (>= 3.5, < 5)
     climate_control (0.2.0)
     clipboard-rails (1.7.1)
-    cocoon (1.2.12)
+    cocoon (1.2.14)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.5)
@@ -214,7 +207,7 @@ GEM
     crass (1.0.4)
     cronex (0.6.1)
       unicode
-    delayed_job (4.1.5)
+    delayed_job (4.1.7)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
       activerecord (>= 3.0, < 5.3)
@@ -233,17 +226,21 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    devise-security (0.14.3)
+      devise (>= 4.3.0, < 5.0)
+      rails (>= 4.2.0, < 7.0)
     diff-lcs (1.3)
-    dotenv (2.5.0)
-    dotenv-rails (2.5.0)
-      dotenv (= 2.5.0)
-      railties (>= 3.2, < 6.0)
+    dotenv (2.7.4)
+    dotenv-rails (2.7.4)
+      dotenv (= 2.7.4)
+      railties (>= 3.2, < 6.1)
     dumb_delegator (0.8.0)
     email_validator (1.6.0)
       activemodel
     enumerize (2.3.1)
       activesupport (>= 3.2)
     equalizer (0.0.11)
+    equatable (0.6.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     errbase (0.1.1)
@@ -254,8 +251,13 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
-    faker (1.9.3)
+    faker (1.9.4)
       i18n (>= 0.7)
+      pastel (~> 0.7.2)
+      thor (~> 0.20.0)
+      tty-pager (~> 0.12.0)
+      tty-screen (~> 0.6.5)
+      tty-tree (~> 0.3.0)
     ffi (1.11.1)
     font-awesome-sass (5.8.1)
       sassc (>= 1.11)
@@ -278,7 +280,7 @@ GEM
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-datatables-rails (3.4.0)
@@ -286,7 +288,7 @@ GEM
       jquery-rails
       railties (>= 3.1)
       sass-rails
-    jquery-rails (4.3.3)
+    jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -349,6 +351,9 @@ GEM
       activerecord (>= 4.0, < 6.1)
     parser (2.6.3.0)
       ast (~> 2.4.0)
+    pastel (0.7.3)
+      equatable (~> 0.6)
+      tty-color (~> 0.5)
     pdf-core (0.7.0)
     pdf-reader (2.2.0)
       Ascii85 (~> 1.0.0)
@@ -360,12 +365,12 @@ GEM
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
-    public_suffix (3.1.0)
+    public_suffix (3.1.1)
     puma (3.12.1)
     pundit (2.0.1)
       activesupport (>= 3.0.0)
     rack (2.0.7)
-    rack-attack (5.4.2)
+    rack-attack (6.0.0)
       rack (>= 1.0, < 3)
     rack-protection (2.0.5)
       rack
@@ -413,15 +418,15 @@ GEM
     regexp_property_values (0.3.5)
     request_store (1.4.1)
       rack (>= 1.4)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
-    rspec-core (3.8.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
+    rspec-core (3.8.1)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.3)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-rails (3.8.2)
@@ -432,21 +437,21 @@ GEM
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+    rspec-support (3.8.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.71.0)
+    rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.3.0)
-      rubocop (>= 0.68.0)
-    rubocop-rails (2.0.1)
+    rubocop-performance (1.4.0)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.1.0)
       rack (>= 1.1)
-      rubocop (>= 0.70.0)
+      rubocop (>= 0.72.0)
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
     ruby-hl7 (1.2.3)
@@ -466,7 +471,7 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
-    sassc-rails (2.1.1)
+    sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
       sprockets (> 3.0)
@@ -475,7 +480,7 @@ GEM
     scenic (1.5.1)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    shoulda-matchers (4.0.1)
+    shoulda-matchers (4.1.0)
       activesupport (>= 4.2.0)
     simple_form (4.1.0)
       actionpack (>= 5.0)
@@ -499,12 +504,25 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strings (0.1.5)
+      strings-ansi (~> 0.1)
+      unicode-display_width (~> 1.5)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.1.0)
     temple (0.8.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    timeliness (0.3.10)
+    timeliness (0.4.3)
     ttfunk (1.5.1)
+    tty-color (0.5.0)
+    tty-pager (0.12.1)
+      strings (~> 0.1.4)
+      tty-screen (~> 0.6)
+      tty-which (~> 0.4)
+    tty-screen (0.6.5)
+    tty-tree (0.3.0)
+    tty-which (0.4.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -512,9 +530,10 @@ GEM
     underscore-rails (1.8.3)
     unicode (0.4.4.4)
     unicode-display_width (1.6.0)
+    unicode_utils (1.4.0)
     user_agent_parser (2.5.1)
-    validates_timeliness (4.0.2)
-      timeliness (~> 0.3.7)
+    validates_timeliness (4.1.0)
+      timeliness (>= 0.3.10, < 1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -526,12 +545,13 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
-    whenever (0.10.0)
+    websocket-extensions (0.1.4)
+    whenever (1.0.0)
       chronic (>= 0.6.3)
-    wicked_pdf (1.1.0)
+    wicked_pdf (1.4.0)
+      activesupport
     wisper (2.0.0)
     wisper-activejob (1.0.0)
       activejob (>= 4.0.0)
@@ -552,8 +572,6 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   climate_control
-  devise_security_extension!
-  dotenv-rails (~> 2.5.0)
   equivalent-xml
   factory_bot_rails
   faker

--- a/renalware-diaverum.gemspec
+++ b/renalware-diaverum.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "dotenv-rails"
+  s.add_dependency "dotenv-rails", "~> 2.5"
   s.add_dependency "pg", "~> 1.0"
   s.add_dependency "rails", ">= 5.1"
 end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1029,6 +1029,74 @@ ALTER SEQUENCE access_versions_id_seq OWNED BY access_versions.id;
 
 
 --
+-- Name: active_storage_attachments; Type: TABLE; Schema: renalware; Owner: -
+--
+
+CREATE TABLE active_storage_attachments (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    record_type character varying NOT NULL,
+    record_id bigint NOT NULL,
+    blob_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: active_storage_attachments_id_seq; Type: SEQUENCE; Schema: renalware; Owner: -
+--
+
+CREATE SEQUENCE active_storage_attachments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: active_storage_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware; Owner: -
+--
+
+ALTER SEQUENCE active_storage_attachments_id_seq OWNED BY active_storage_attachments.id;
+
+
+--
+-- Name: active_storage_blobs; Type: TABLE; Schema: renalware; Owner: -
+--
+
+CREATE TABLE active_storage_blobs (
+    id bigint NOT NULL,
+    key character varying NOT NULL,
+    filename character varying NOT NULL,
+    content_type character varying,
+    metadata text,
+    byte_size bigint NOT NULL,
+    checksum character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: active_storage_blobs_id_seq; Type: SEQUENCE; Schema: renalware; Owner: -
+--
+
+CREATE SEQUENCE active_storage_blobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: active_storage_blobs_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware; Owner: -
+--
+
+ALTER SEQUENCE active_storage_blobs_id_seq OWNED BY active_storage_blobs.id;
+
+
+--
 -- Name: addresses; Type: TABLE; Schema: renalware; Owner: -
 --
 
@@ -3540,7 +3608,8 @@ CREATE TABLE modality_descriptions (
     deleted_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    hidden boolean DEFAULT false NOT NULL
+    hidden boolean DEFAULT false NOT NULL,
+    ukrdc_modality_code_id bigint
 );
 
 
@@ -7028,7 +7097,10 @@ CREATE TABLE transplant_recipient_followups (
     document jsonb,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    graft_nephrectomy_on date
+    graft_nephrectomy_on date,
+    graft_function_onset character varying,
+    last_post_transplant_dialysis_on date,
+    return_to_regular_dialysis_on date
 );
 
 
@@ -7220,6 +7292,74 @@ ALTER SEQUENCE transplant_registrations_id_seq OWNED BY transplant_registrations
 
 
 --
+-- Name: transplant_rejection_episodes; Type: TABLE; Schema: renalware; Owner: -
+--
+
+CREATE TABLE transplant_rejection_episodes (
+    id bigint NOT NULL,
+    recorded_on date NOT NULL,
+    notes text,
+    followup_id bigint NOT NULL,
+    updated_by_id bigint NOT NULL,
+    created_by_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    treatment_id bigint
+);
+
+
+--
+-- Name: transplant_rejection_episodes_id_seq; Type: SEQUENCE; Schema: renalware; Owner: -
+--
+
+CREATE SEQUENCE transplant_rejection_episodes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: transplant_rejection_episodes_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware; Owner: -
+--
+
+ALTER SEQUENCE transplant_rejection_episodes_id_seq OWNED BY transplant_rejection_episodes.id;
+
+
+--
+-- Name: transplant_rejection_treatments; Type: TABLE; Schema: renalware; Owner: -
+--
+
+CREATE TABLE transplant_rejection_treatments (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    "position" integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: transplant_rejection_treatments_id_seq; Type: SEQUENCE; Schema: renalware; Owner: -
+--
+
+CREATE SEQUENCE transplant_rejection_treatments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: transplant_rejection_treatments_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware; Owner: -
+--
+
+ALTER SEQUENCE transplant_rejection_treatments_id_seq OWNED BY transplant_rejection_treatments.id;
+
+
+--
 -- Name: transplant_versions; Type: TABLE; Schema: renalware; Owner: -
 --
 
@@ -7354,6 +7494,45 @@ CREATE SEQUENCE ukrdc_transmission_logs_id_seq
 --
 
 ALTER SEQUENCE ukrdc_transmission_logs_id_seq OWNED BY ukrdc_transmission_logs.id;
+
+
+--
+-- Name: ukrdc_treatments; Type: TABLE; Schema: renalware; Owner: -
+--
+
+CREATE TABLE ukrdc_treatments (
+    id bigint NOT NULL,
+    patient_id bigint NOT NULL,
+    clinician_id bigint,
+    modality_code_id bigint NOT NULL,
+    modality_id bigint,
+    modality_description_id bigint,
+    hospital_centre_id bigint,
+    hospital_unit_id bigint,
+    started_on date NOT NULL,
+    ended_on date,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: ukrdc_treatments_id_seq; Type: SEQUENCE; Schema: renalware; Owner: -
+--
+
+CREATE SEQUENCE ukrdc_treatments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ukrdc_treatments_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware; Owner: -
+--
+
+ALTER SEQUENCE ukrdc_treatments_id_seq OWNED BY ukrdc_treatments.id;
 
 
 --
@@ -7514,74 +7693,6 @@ ALTER SEQUENCE access_maps_id_seq OWNED BY access_maps.id;
 
 
 --
--- Name: active_storage_attachments; Type: TABLE; Schema: renalware_diaverum; Owner: -
---
-
-CREATE TABLE active_storage_attachments (
-    id bigint NOT NULL,
-    name character varying NOT NULL,
-    record_type character varying NOT NULL,
-    record_id bigint NOT NULL,
-    blob_id bigint NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: active_storage_attachments_id_seq; Type: SEQUENCE; Schema: renalware_diaverum; Owner: -
---
-
-CREATE SEQUENCE active_storage_attachments_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: active_storage_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware_diaverum; Owner: -
---
-
-ALTER SEQUENCE active_storage_attachments_id_seq OWNED BY active_storage_attachments.id;
-
-
---
--- Name: active_storage_blobs; Type: TABLE; Schema: renalware_diaverum; Owner: -
---
-
-CREATE TABLE active_storage_blobs (
-    id bigint NOT NULL,
-    key character varying NOT NULL,
-    filename character varying NOT NULL,
-    content_type character varying,
-    metadata text,
-    byte_size bigint NOT NULL,
-    checksum character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: active_storage_blobs_id_seq; Type: SEQUENCE; Schema: renalware_diaverum; Owner: -
---
-
-CREATE SEQUENCE active_storage_blobs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: active_storage_blobs_id_seq; Type: SEQUENCE OWNED BY; Schema: renalware_diaverum; Owner: -
---
-
-ALTER SEQUENCE active_storage_blobs_id_seq OWNED BY active_storage_blobs.id;
-
-
---
 -- Name: hd_type_maps; Type: TABLE; Schema: renalware_diaverum; Owner: -
 --
 
@@ -7676,6 +7787,20 @@ ALTER TABLE ONLY access_types ALTER COLUMN id SET DEFAULT nextval('access_types_
 --
 
 ALTER TABLE ONLY access_versions ALTER COLUMN id SET DEFAULT nextval('access_versions_id_seq'::regclass);
+
+
+--
+-- Name: active_storage_attachments id; Type: DEFAULT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('active_storage_attachments_id_seq'::regclass);
+
+
+--
+-- Name: active_storage_blobs id; Type: DEFAULT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('active_storage_blobs_id_seq'::regclass);
 
 
 --
@@ -8715,6 +8840,20 @@ ALTER TABLE ONLY transplant_registrations ALTER COLUMN id SET DEFAULT nextval('t
 
 
 --
+-- Name: transplant_rejection_episodes id; Type: DEFAULT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_episodes ALTER COLUMN id SET DEFAULT nextval('transplant_rejection_episodes_id_seq'::regclass);
+
+
+--
+-- Name: transplant_rejection_treatments id; Type: DEFAULT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_treatments ALTER COLUMN id SET DEFAULT nextval('transplant_rejection_treatments_id_seq'::regclass);
+
+
+--
 -- Name: transplant_versions id; Type: DEFAULT; Schema: renalware; Owner: -
 --
 
@@ -8740,6 +8879,13 @@ ALTER TABLE ONLY ukrdc_modality_codes ALTER COLUMN id SET DEFAULT nextval('ukrdc
 --
 
 ALTER TABLE ONLY ukrdc_transmission_logs ALTER COLUMN id SET DEFAULT nextval('ukrdc_transmission_logs_id_seq'::regclass);
+
+
+--
+-- Name: ukrdc_treatments id; Type: DEFAULT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments ALTER COLUMN id SET DEFAULT nextval('ukrdc_treatments_id_seq'::regclass);
 
 
 --
@@ -8777,20 +8923,6 @@ SET search_path = renalware_diaverum, pg_catalog;
 --
 
 ALTER TABLE ONLY access_maps ALTER COLUMN id SET DEFAULT nextval('access_maps_id_seq'::regclass);
-
-
---
--- Name: active_storage_attachments id; Type: DEFAULT; Schema: renalware_diaverum; Owner: -
---
-
-ALTER TABLE ONLY active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('active_storage_attachments_id_seq'::regclass);
-
-
---
--- Name: active_storage_blobs id; Type: DEFAULT; Schema: renalware_diaverum; Owner: -
---
-
-ALTER TABLE ONLY active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('active_storage_blobs_id_seq'::regclass);
 
 
 --
@@ -8890,6 +9022,22 @@ ALTER TABLE ONLY access_types
 
 ALTER TABLE ONLY access_versions
     ADD CONSTRAINT access_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY active_storage_attachments
+    ADD CONSTRAINT active_storage_attachments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: active_storage_blobs active_storage_blobs_pkey; Type: CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY active_storage_blobs
+    ADD CONSTRAINT active_storage_blobs_pkey PRIMARY KEY (id);
 
 
 --
@@ -10085,6 +10233,22 @@ ALTER TABLE ONLY transplant_registrations
 
 
 --
+-- Name: transplant_rejection_episodes transplant_rejection_episodes_pkey; Type: CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_episodes
+    ADD CONSTRAINT transplant_rejection_episodes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transplant_rejection_treatments transplant_rejection_treatments_pkey; Type: CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_treatments
+    ADD CONSTRAINT transplant_rejection_treatments_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: transplant_versions transplant_versions_pkey; Type: CONSTRAINT; Schema: renalware; Owner: -
 --
 
@@ -10114,6 +10278,14 @@ ALTER TABLE ONLY ukrdc_modality_codes
 
 ALTER TABLE ONLY ukrdc_transmission_logs
     ADD CONSTRAINT ukrdc_transmission_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ukrdc_treatments ukrdc_treatments_pkey; Type: CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT ukrdc_treatments_pkey PRIMARY KEY (id);
 
 
 --
@@ -10156,22 +10328,6 @@ SET search_path = renalware_diaverum, pg_catalog;
 
 ALTER TABLE ONLY access_maps
     ADD CONSTRAINT access_maps_pkey PRIMARY KEY (id);
-
-
---
--- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: renalware_diaverum; Owner: -
---
-
-ALTER TABLE ONLY active_storage_attachments
-    ADD CONSTRAINT active_storage_attachments_pkey PRIMARY KEY (id);
-
-
---
--- Name: active_storage_blobs active_storage_blobs_pkey; Type: CONSTRAINT; Schema: renalware_diaverum; Owner: -
---
-
-ALTER TABLE ONLY active_storage_blobs
-    ADD CONSTRAINT active_storage_blobs_pkey PRIMARY KEY (id);
 
 
 --
@@ -10448,6 +10604,27 @@ CREATE INDEX index_access_profiles_on_type_id ON access_profiles USING btree (ty
 --
 
 CREATE INDEX index_access_profiles_on_updated_by_id ON access_profiles USING btree (updated_by_id);
+
+
+--
+-- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_active_storage_attachments_on_blob_id ON active_storage_attachments USING btree (blob_id);
+
+
+--
+-- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON active_storage_attachments USING btree (record_type, record_id, name, blob_id);
+
+
+--
+-- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON active_storage_blobs USING btree (key);
 
 
 --
@@ -11904,6 +12081,13 @@ CREATE INDEX index_modality_descriptions_on_id_and_type ON modality_descriptions
 --
 
 CREATE INDEX index_modality_descriptions_on_name ON modality_descriptions USING btree (name);
+
+
+--
+-- Name: index_modality_descriptions_on_ukrdc_modality_code_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_modality_descriptions_on_ukrdc_modality_code_id ON modality_descriptions USING btree (ukrdc_modality_code_id);
 
 
 --
@@ -13391,6 +13575,48 @@ CREATE INDEX index_transplant_registrations_on_patient_id ON transplant_registra
 
 
 --
+-- Name: index_transplant_rejection_episodes_on_created_by_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_transplant_rejection_episodes_on_created_by_id ON transplant_rejection_episodes USING btree (created_by_id);
+
+
+--
+-- Name: index_transplant_rejection_episodes_on_followup_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_transplant_rejection_episodes_on_followup_id ON transplant_rejection_episodes USING btree (followup_id);
+
+
+--
+-- Name: index_transplant_rejection_episodes_on_treatment_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_transplant_rejection_episodes_on_treatment_id ON transplant_rejection_episodes USING btree (treatment_id);
+
+
+--
+-- Name: index_transplant_rejection_episodes_on_updated_by_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_transplant_rejection_episodes_on_updated_by_id ON transplant_rejection_episodes USING btree (updated_by_id);
+
+
+--
+-- Name: index_transplant_rejection_treatments_on_name; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_transplant_rejection_treatments_on_name ON transplant_rejection_treatments USING btree (name);
+
+
+--
+-- Name: index_transplant_rejection_treatments_on_position; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_transplant_rejection_treatments_on_position ON transplant_rejection_treatments USING btree ("position");
+
+
+--
 -- Name: index_ukrdc_modality_codes_on_qbl_code; Type: INDEX; Schema: renalware; Owner: -
 --
 
@@ -13416,6 +13642,55 @@ CREATE INDEX index_ukrdc_transmission_logs_on_patient_id ON ukrdc_transmission_l
 --
 
 CREATE INDEX index_ukrdc_transmission_logs_on_request_uuid ON ukrdc_transmission_logs USING btree (request_uuid);
+
+
+--
+-- Name: index_ukrdc_treatments_on_clinician_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_clinician_id ON ukrdc_treatments USING btree (clinician_id);
+
+
+--
+-- Name: index_ukrdc_treatments_on_hospital_centre_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_hospital_centre_id ON ukrdc_treatments USING btree (hospital_centre_id);
+
+
+--
+-- Name: index_ukrdc_treatments_on_hospital_unit_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_hospital_unit_id ON ukrdc_treatments USING btree (hospital_unit_id);
+
+
+--
+-- Name: index_ukrdc_treatments_on_modality_code_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_modality_code_id ON ukrdc_treatments USING btree (modality_code_id);
+
+
+--
+-- Name: index_ukrdc_treatments_on_modality_description_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_modality_description_id ON ukrdc_treatments USING btree (modality_description_id);
+
+
+--
+-- Name: index_ukrdc_treatments_on_modality_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_modality_id ON ukrdc_treatments USING btree (modality_id);
+
+
+--
+-- Name: index_ukrdc_treatments_on_patient_id; Type: INDEX; Schema: renalware; Owner: -
+--
+
+CREATE INDEX index_ukrdc_treatments_on_patient_id ON ukrdc_treatments USING btree (patient_id);
 
 
 --
@@ -13666,27 +13941,6 @@ CREATE UNIQUE INDEX unique_study_participants ON research_study_participants USI
 SET search_path = renalware_diaverum, pg_catalog;
 
 --
--- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: renalware_diaverum; Owner: -
---
-
-CREATE INDEX index_active_storage_attachments_on_blob_id ON active_storage_attachments USING btree (blob_id);
-
-
---
--- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: renalware_diaverum; Owner: -
---
-
-CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON active_storage_attachments USING btree (record_type, record_id, name, blob_id);
-
-
---
--- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: renalware_diaverum; Owner: -
---
-
-CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON active_storage_blobs USING btree (key);
-
-
---
 -- Name: index_renalware_diaverum.hd_type_maps_on_diaverum_type_id; Type: INDEX; Schema: renalware_diaverum; Owner: -
 --
 
@@ -13900,6 +14154,14 @@ ALTER TABLE ONLY hd_profiles
 
 
 --
+-- Name: transplant_rejection_episodes fk_rails_0b121fa111; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_episodes
+    ADD CONSTRAINT fk_rails_0b121fa111 FOREIGN KEY (created_by_id) REFERENCES users(id);
+
+
+--
 -- Name: transplant_donations fk_rails_0b66891291; Type: FK CONSTRAINT; Schema: renalware; Owner: -
 --
 
@@ -14060,6 +14322,14 @@ ALTER TABLE ONLY admission_consults
 
 
 --
+-- Name: ukrdc_treatments fk_rails_2a03129a59; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT fk_rails_2a03129a59 FOREIGN KEY (modality_code_id) REFERENCES ukrdc_modality_codes(id);
+
+
+--
 -- Name: medication_prescriptions fk_rails_2ae6a3ad59; Type: FK CONSTRAINT; Schema: renalware; Owner: -
 --
 
@@ -14073,6 +14343,14 @@ ALTER TABLE ONLY medication_prescriptions
 
 ALTER TABLE ONLY medication_prescription_terminations
     ADD CONSTRAINT fk_rails_2bd34b98f9 FOREIGN KEY (created_by_id) REFERENCES users(id);
+
+
+--
+-- Name: ukrdc_treatments fk_rails_2bf0a6c5e9; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT fk_rails_2bf0a6c5e9 FOREIGN KEY (clinician_id) REFERENCES users(id);
 
 
 --
@@ -14460,6 +14738,14 @@ ALTER TABLE ONLY patient_practice_memberships
 
 
 --
+-- Name: transplant_rejection_episodes fk_rails_5eed551513; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_episodes
+    ADD CONSTRAINT fk_rails_5eed551513 FOREIGN KEY (followup_id) REFERENCES transplant_recipient_followups(id);
+
+
+--
 -- Name: pd_regime_terminations fk_rails_6021bed852; Type: FK CONSTRAINT; Schema: renalware; Owner: -
 --
 
@@ -14604,11 +14890,27 @@ ALTER TABLE ONLY hd_profiles
 
 
 --
+-- Name: ukrdc_treatments fk_rails_7d0d8e5131; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT fk_rails_7d0d8e5131 FOREIGN KEY (modality_description_id) REFERENCES modality_descriptions(id);
+
+
+--
 -- Name: pd_regime_terminations fk_rails_7d318fdf1a; Type: FK CONSTRAINT; Schema: renalware; Owner: -
 --
 
 ALTER TABLE ONLY pd_regime_terminations
     ADD CONSTRAINT fk_rails_7d318fdf1a FOREIGN KEY (regime_id) REFERENCES pd_regimes(id);
+
+
+--
+-- Name: ukrdc_treatments fk_rails_7d4def4f31; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT fk_rails_7d4def4f31 FOREIGN KEY (hospital_centre_id) REFERENCES hospital_centres(id);
 
 
 --
@@ -14788,6 +15090,14 @@ ALTER TABLE ONLY clinical_allergies
 
 
 --
+-- Name: transplant_rejection_episodes fk_rails_93bb09b431; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_episodes
+    ADD CONSTRAINT fk_rails_93bb09b431 FOREIGN KEY (updated_by_id) REFERENCES users(id);
+
+
+--
 -- Name: transplant_donor_workups fk_rails_93dc1108f3; Type: FK CONSTRAINT; Schema: renalware; Owner: -
 --
 
@@ -14825,6 +15135,14 @@ ALTER TABLE ONLY patients
 
 ALTER TABLE ONLY research_study_participants
     ADD CONSTRAINT fk_rails_980af0ec33 FOREIGN KEY (participant_id) REFERENCES patients(id);
+
+
+--
+-- Name: transplant_rejection_episodes fk_rails_98de4be6aa; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY transplant_rejection_episodes
+    ADD CONSTRAINT fk_rails_98de4be6aa FOREIGN KEY (treatment_id) REFERENCES transplant_rejection_treatments(id);
 
 
 --
@@ -14929,6 +15247,14 @@ ALTER TABLE ONLY letter_contacts
 
 ALTER TABLE ONLY hd_patient_statistics
     ADD CONSTRAINT fk_rails_a654a17f8d FOREIGN KEY (hospital_unit_id) REFERENCES hospital_units(id);
+
+
+--
+-- Name: modality_descriptions fk_rails_a6efc804a5; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY modality_descriptions
+    ADD CONSTRAINT fk_rails_a6efc804a5 FOREIGN KEY (ukrdc_modality_code_id) REFERENCES ukrdc_modality_codes(id);
 
 
 --
@@ -15172,11 +15498,27 @@ ALTER TABLE ONLY modality_modalities
 
 
 --
+-- Name: ukrdc_treatments fk_rails_c35a48f8d3; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT fk_rails_c35a48f8d3 FOREIGN KEY (patient_id) REFERENCES patients(id);
+
+
+--
 -- Name: patient_alerts fk_rails_c37cc03264; Type: FK CONSTRAINT; Schema: renalware; Owner: -
 --
 
 ALTER TABLE ONLY patient_alerts
     ADD CONSTRAINT fk_rails_c37cc03264 FOREIGN KEY (created_by_id) REFERENCES users(id);
+
+
+--
+-- Name: active_storage_attachments fk_rails_c3b3935057; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY active_storage_attachments
+    ADD CONSTRAINT fk_rails_c3b3935057 FOREIGN KEY (blob_id) REFERENCES active_storage_blobs(id);
 
 
 --
@@ -15281,6 +15623,14 @@ ALTER TABLE ONLY admission_requests
 
 ALTER TABLE ONLY letter_signatures
     ADD CONSTRAINT fk_rails_d4aaa80dee FOREIGN KEY (letter_id) REFERENCES letter_letters(id);
+
+
+--
+-- Name: ukrdc_treatments fk_rails_d5e9d1f118; Type: FK CONSTRAINT; Schema: renalware; Owner: -
+--
+
+ALTER TABLE ONLY ukrdc_treatments
+    ADD CONSTRAINT fk_rails_d5e9d1f118 FOREIGN KEY (hospital_unit_id) REFERENCES hospital_units(id);
 
 
 --
@@ -15923,16 +16273,6 @@ ALTER TABLE ONLY transplant_registration_statuses
     ADD CONSTRAINT transplant_registration_statuses_updated_by_id_fk FOREIGN KEY (updated_by_id) REFERENCES users(id);
 
 
-SET search_path = renalware_diaverum, pg_catalog;
-
---
--- Name: active_storage_attachments fk_rails_c3b3935057; Type: FK CONSTRAINT; Schema: renalware_diaverum; Owner: -
---
-
-ALTER TABLE ONLY active_storage_attachments
-    ADD CONSTRAINT fk_rails_c3b3935057 FOREIGN KEY (blob_id) REFERENCES active_storage_blobs(id);
-
-
 --
 -- PostgreSQL database dump complete
 --
@@ -16370,11 +16710,16 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190513131826'),
 ('20190513135312'),
 ('20190516093707'),
+('20190520091324'),
 ('20190531172829'),
 ('20190602114659'),
 ('20190603084428'),
 ('20190603135247'),
 ('20190603143834'),
-('20190603165812');
+('20190603165812'),
+('20190607134717'),
+('20190611152859'),
+('20190612124015'),
+('20190617121528');
 
 


### PR DESCRIPTION
Update also
- capybara (3.24.0)
- capybara-screenshot (1.0.23)
- cocoon (1.2.14)
- delayed_job (4.1.7)
- devise-security (0.14.3)
- wicked_pdf (1.4.0
- whenever (1.0.0)
-  shoulda-matchers (4.1.0)
- dotenv (2.7.4)
- dotenv-rails (2.7.4)
- faker (1.9.4)
- jquery-rails (4.3.5)
- rack-attack (6.0.0)
- rspec-core (3.8.1)
-  rubocop (0.72.0
- rubocop-performance (1.4.0)
- sassc-rails (2.1.2)