### PR TITLE
Run rake yarn:install before rails server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ this [changelog](http://keepachangelog.com/en/0.3.0/).
 This project adheres to Semantic Versioning.
 
 ## Unreleased
+### Added
+### Changed
+### Fixed
+
+## 1.0.8
+19-11-2019
+### Added
+### Changed
+- Remove webpacker depdendency
+### Fixed
 
 ## 1.0.8
 18-11-2019

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GIT
 PATH
   remote: .
   specs:
-    renalware-diaverum (1.0.8)
+    renalware-diaverum (1.0.9)
       dotenv-rails (~> 2.5)
       pg (~> 1.0)
       rails (>= 5.1)

--- a/bin/web
+++ b/bin/web
@@ -1,2 +1,3 @@
 #!/bin/sh
+bundle exec rake app:yarn:install
 bundle exec ./spec/dummy/bin/rails server

--- a/lib/renalware/diaverum/version.rb
+++ b/lib/renalware/diaverum/version.rb
@@ -2,6 +2,6 @@
 
 module Renalware
   module Diaverum
-    VERSION = "1.0.8"
+    VERSION = "1.0.9"
   end
 end


### PR DESCRIPTION
Update bin/web to run rake yarn:install before running rails server. Not other way atm to install renalware-core js dependencies automatically