### PR TITLE
Add ability to recreate missing .hl7 path results files for one patien

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ This project adheres to Semantic Versioning.
 ### Changed
 ### Fixed
 
-## 1.0.8
+## 1.0.10
+22-11-2019
+### Added
+### Changed
+- Add ability to recreate missing .hl7 path results files for one specific patient
+### Fixed
+
+## 1.0.9
 19-11-2019
 ### Added
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GIT
 PATH
   remote: .
   specs:
-    renalware-diaverum (1.0.9)
+    renalware-diaverum (1.0.10)
       dotenv-rails (~> 2.5)
       pg (~> 1.0)
       rails (>= 5.1)

--- a/lib/renalware/diaverum/version.rb
+++ b/lib/renalware/diaverum/version.rb
@@ -2,6 +2,6 @@
 
 module Renalware
   module Diaverum
-    VERSION = "1.0.9"
+    VERSION = "1.0.10"
   end
 end

--- a/lib/tasks/create_missing_pathology.rake
+++ b/lib/tasks/create_missing_pathology.rake
@@ -6,27 +6,32 @@ namespace :diaverum do
   desc "Re-creates missing pathology .hl7 files for Diaverum patients for a given period "\
        "example usage "\
        "rake diaverum:recreate_pathology_files from_date=2019-10-30 to_date=2019-11-15"
+  # You can also pass in a local_patient_id eg Z00001
   task recreate_pathology_files: :environment do
     from_date = DateTime.parse(ENV.fetch("from_date")).beginning_of_day
     to_date = DateTime.parse(ENV.fetch("to_date")).end_of_day
+    local_patient_id = ENV["local_patient_id"]
 
     diaverum_unit_ids = Renalware::HD::ProviderUnit
       .joins(:hd_provider)
       .where("hd_providers.name ilike 'Diaverum'")
       .pluck(:hospital_unit_id)
 
-    local_patient_ids = Renalware::HD::Patient
-      .joins(hd_profile: :hospital_unit)
-      .where(hd_profiles: { hospital_unit_id: diaverum_unit_ids })
-      .pluck(:local_patient_id)
+    local_patient_ids = Array(local_patient_id).compact
+    if local_patient_ids.empty?
+      local_patient_ids = Renalware::HD::Patient
+        .joins(hd_profile: :hospital_unit)
+        .where(hd_profiles: { hospital_unit_id: diaverum_unit_ids })
+        .pluck(:local_patient_id)
+    end
 
     messages = Renalware::Feeds::Message
       .where(patient_identifier: local_patient_ids)
       .where("created_at >= ? and created_at < ?", from_date, to_date)
       .where("event_code like 'ORU%'")
 
-    puts "Using diaverum unit ids #{diaverum_unit_ids.join(', ')}"
-    puts "Applying to patients with local_patient_ids #{local_patient_ids.join(', ')}"
+    puts "Using diaverum unit ids: #{diaverum_unit_ids.join(', ')}"
+    puts "Applying to patients with local_patient_ids: #{local_patient_ids.join(', ')}"
     puts "Between #{from_date} and #{to_date}"
 
     if messages.length.zero?


### PR DESCRIPTION
Alter the current rake task to accept a local_patient_id ENV param which will be used rather than looking up all affected patients.