### PR TITLE
Use nhs_number not local_patient_id to resolve patients

### DIFF
--- a/app/models/renalware/diaverum/outgoing/pathology_listener.rb
+++ b/app/models/renalware/diaverum/outgoing/pathology_listener.rb
@@ -18,10 +18,10 @@ module Renalware
 
         def oru_message_processed(args)
           feed_message = args[:feed_message]
-          local_patient_id = feed_message.patient_identifier
-          return if local_patient_id.blank?
+          nhs_number = feed_message.patient_identifier
+          return if nhs_number.blank?
 
-          patient = find_diaverum_patient(local_patient_id)
+          patient = find_diaverum_patient(nhs_number)
           return if patient.blank?
 
           ForwardHl7Job.perform_later(
@@ -31,8 +31,8 @@ module Renalware
 
         private
 
-        def find_diaverum_patient(local_patient_id)
-          PatientQuery.new(local_patient_id: local_patient_id).call
+        def find_diaverum_patient(nhs_number)
+          PatientQuery.new(nhs_number: nhs_number).call
         end
 
         def transmission_log_for(patient, feed_message)

--- a/app/models/renalware/diaverum/outgoing/patient_query.rb
+++ b/app/models/renalware/diaverum/outgoing/patient_query.rb
@@ -7,7 +7,7 @@ module Renalware
     module Outgoing
       # Find HD Patients dialysing at a particular hospital unit.
       class PatientQuery
-        pattr_initialize [:local_patient_id!]
+        pattr_initialize [:nhs_number!]
 
         def self.call(*args)
           new(*args).call
@@ -21,7 +21,7 @@ module Renalware
             .where("hd_profiles.hospital_unit_id in (?)", diaverum_hospital_unit_ids)
             .extending(Renalware::ModalityScopes)
             .with_current_modality_matching("HD")
-            .find_by(local_patient_id: local_patient_id)
+            .find_by(nhs_number: nhs_number)
         end
 
         private

--- a/spec/models/renalware/diaverum/outgoing/pathology_listener_spec.rb
+++ b/spec/models/renalware/diaverum/outgoing/pathology_listener_spec.rb
@@ -7,7 +7,7 @@ module Renalware
     RSpec.describe Outgoing::PathologyListener do
       subject(:listener) { described_class }
 
-      it "does nothing if feed_message local_patient_id is blank" do
+      it "does nothing if feed_message patient_identifier is blank" do
         feed_message = double(:feed_message, body: "123", patient_identifier: nil)
         allow(Outgoing::ForwardHl7Job).to receive(:perform_later)
 
@@ -26,8 +26,8 @@ module Renalware
       end
 
       it "calls ForwardHl7Job if patient found" do
-        patient = Patient.new(local_patient_id: "XYZ")
-        feed_message = double(:feed_message, body: "123", patient_identifier: "XYZ")
+        patient = Patient.new(nhs_number: "9338503739")
+        feed_message = double(:feed_message, body: "123", patient_identifier: "9338503739")
         allow_any_instance_of(Outgoing::PatientQuery).to receive(:call).and_return(patient)
 
         allow(Outgoing::ForwardHl7Job).to receive(:perform_later)

--- a/spec/models/renalware/diaverum/outgoing/patient_query_spec.rb
+++ b/spec/models/renalware/diaverum/outgoing/patient_query_spec.rb
@@ -6,27 +6,27 @@ module Renalware
   module Diaverum
     RSpec.describe Outgoing::PatientQuery do
       include PatientsSpecHelper
-      subject(:query) { described_class.new(local_patient_id: local_hospital_id).call }
+      subject(:query) { described_class.new(nhs_number: nhs_number).call }
 
       let(:provider) { HD::Provider.new(name: "Diaverum") }
 
-      context "when a nil local_patient_id argument is passed" do
-        let(:local_hospital_id) { nil }
+      context "when a nil nhs_number argument is passed" do
+        let(:nhs_number) { nil }
 
         it { is_expected.to be_nil }
       end
 
-      context "when a local_patient_id is passed" do
+      context "when a nhs_number is passed" do
         context "when the patient is not found" do
-          let(:local_hospital_id) { "hosp id of patient not on the system" }
+          let(:nhs_number) { "nhs_number_for_pd_patient" }
 
           it { is_expected.to be_nil }
         end
 
         context "when patient is found" do
-          let(:local_hospital_id) { "123" }
+          let(:nhs_number) { "1741581516" }
           let!(:patient) do
-            create(:hd_patient, local_patient_id: local_hospital_id) do |pat|
+            create(:hd_patient, nhs_number: nhs_number) do |pat|
               set_modality(
                 patient: pat,
                 modality_description: create(:hd_modality_description)


### PR DESCRIPTION
As feed_messages.patient_identifier now stores the nhs_number use that to locate a diaverum patient when deciding whether to create a .hl7 file for them (file will be sent to Diaverum eg monthly bloods).

To re-create missed hl7 files
```
Renalware::Feeds::Message.where(event_code: "ORU^R01").where('created_at > ?', '2022-02-02 13:00:00').each { |m| 
>> Renalware::Diaverum::Outgoing::PathologyListener.oru_message_processed(feed_message: m) }
```