### PR TITLE
No longer use async when subscribing to RW events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to Semantic Versioning.
 ### Changed
 ### Fixed
 
+## 1.0.14
+29-08-2022
+### Added
+### Changed
+- No longer use async (AJ/Wisper) when subscribing to events
+### Fixed
+
 ## 1.0.13
 09-02-2022
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,9 +94,9 @@ GIT
 PATH
   remote: .
   specs:
-    renalware-diaverum (1.0.13)
-      dotenv-rails (~> 2.5)
-      pg (~> 1.0)
+    renalware-diaverum (1.0.14)
+      dotenv-rails
+      pg
       rails (>= 5.1)
 
 GEM
@@ -689,4 +689,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.5
+   2.3.15

--- a/config/initializers/renalware_core.rb
+++ b/config/initializers/renalware_core.rb
@@ -11,8 +11,13 @@ Renalware.configure do |config|
   # defaults.
   map = config.broadcast_subscription_map
   subscribers = map["Renalware::Feeds::MessageProcessor"] ||= []
-  subscribers << Renalware::Broadcasting::Subscriber.new(
-    "Renalware::Diaverum::Outgoing::PathologyListener",
-    async: true
-  )
+
+  # Because of an AJ Serialisation error (serialing HL7Message) its probably simpler if we process
+  # this message inline rather than via Wisper/AJ, and there is no significant performance 
+  # impact.
+  # Renalware::Broadcasting::Subscriber.new(
+  #   "Renalware::Diaverum::Outgoing::PathologyListener",
+  #   async: true
+  # )
+  subscribers << "Renalware::Diaverum::Outgoing::PathologyListener"
 end

--- a/lib/renalware/diaverum/version.rb
+++ b/lib/renalware/diaverum/version.rb
@@ -2,6 +2,6 @@
 
 module Renalware
   module Diaverum
-    VERSION = "1.0.13"
+    VERSION = "1.0.14"
   end
 end

--- a/renalware-diaverum.gemspec
+++ b/renalware-diaverum.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "dotenv-rails", "~> 2.5"
-  s.add_dependency "pg", "~> 1.0"
+  s.add_dependency "dotenv-rails"
+  s.add_dependency "pg"
   s.add_dependency "rails", ">= 5.1"
 end


### PR DESCRIPTION
Its not necessary and we were experiencing AJ serialization errors.